### PR TITLE
fix R CMD check NOTE: no visible binding for urn

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Imports:
     xml2,
     dplyr,
     purrr,
+    rlang,
     rvest
 RoxygenNote: 6.0.1
 Suggests: knitr,

--- a/R/get_perseus_text.R
+++ b/R/get_perseus_text.R
@@ -35,6 +35,6 @@ get_perseus_text <- function(text_urn) {
   df <- extract_text(text_url) %>%
     dplyr::mutate(urn = text_urn) %>%
     dplyr::left_join(internal_perseus_catalog, by = "urn") %>%
-    dplyr::mutate(section = dplyr::row_number(urn))
+    dplyr::mutate(section = dplyr::row_number(.data$urn))
   df
 }

--- a/R/get_perseus_text.R
+++ b/R/get_perseus_text.R
@@ -13,6 +13,7 @@
 #'   \item{language}{Text language, e.g. "grc" = Greek, "lat" = Latin, "eng" = English}
 #' }
 #' @importFrom dplyr %>%
+#' @importFrom rlang .data
 #' @export
 #'
 #' @examples


### PR DESCRIPTION
Explicitly adding `.data$urn` in the `mutate` call to avoid the following NOTE when running R CMD check:

```
get_perseus_text: no visible binding for global variable ‘urn’
Undefined global functions or variables:
  urn
```